### PR TITLE
[ 🚑 HOTFIX ] Removed Refresh Token Hook

### DIFF
--- a/client/src/util/fetchUtils.js
+++ b/client/src/util/fetchUtils.js
@@ -1,5 +1,4 @@
 import Cookies from 'js-cookie'
-import { useSession } from '../hooks/useSessionContext'
 
 export const fetchWithAuth = async ({
     url,
@@ -7,8 +6,6 @@ export const fetchWithAuth = async ({
     data = {},
     headers = {},
 }) => {
-    const { generateToken } = useSession()
-
     // Default headers including Authorization
     const defaultHeaders = {
         'Content-Type': 'application/json',
@@ -31,9 +28,6 @@ export const fetchWithAuth = async ({
 
     // Check for a 400 Unauthorized status code to detect invalid token
     if (response.status === 400) {
-        // refresh token and throw error
-        generateToken()
-
         throw new Error('Invalid token. Please try again.')
     }
 


### PR DESCRIPTION
Unfortunately, the token that refreshes the user's token breaks React's [Rule of Hooks 3](https://react.dev/warnings/invalid-hook-call-warning). The plan is to remove it for now, and implement in the backend token refreshing, instead of on the frontend.

**Hook Removal**
- `client/src/utils/fetchUtils.js` - Removed the ``useSession`` hook along with the call to ``generateToken()`` when a STATUS 400 was returned by an API call. Kept the check for a STATUS 400 and error message for more descriptive error messages.

LONG LIVE PIPELINES 🚀