### PR TITLE
Token Generation Fix + Robust Fetch

### DIFF
--- a/server/middleware/token.js
+++ b/server/middleware/token.js
@@ -33,7 +33,7 @@ const verifyToken = (req, res, next) => {
     next();
   } catch (err) {
     console.error(err);
-    return res.status(400).json({ msg: "Invalid or expired token." });
+    return res.status(401).json({ msg: "Invalid or expired token." });
   }
 };
 


### PR DESCRIPTION
After viewing a strange bug with the fetch calls, specifically with the Early Access page and code entry, I found a few fixes and optimizations for the `fetchWithAuth` helper function.

**Token Generation**
- `client/src/util/fetchUtils.js` - Added an `await` to the `generateToken` call, since the function is asynchronous. This was the issue behind the STATUS 401 error for every second attempt at a fall with an expired token since the second call would have a promise within the `Authorization` header, which is not a valid token structure. This await allows for a proper token to be generated and sent back to the user.
- `server/middleware/token.js` - Changed the status of an expired token from STATUS 400 to STATUS 401, since that is not at the fault of the user, and is the fault of the token/server. Also prevents looping when the `fetchWithAuth` function checks for STATUS 400.

** Robust Fetch**
- `client/src/util/fetchUtils.js` - Added checks for different error properties, including `msg`, `message`, and `error`. This allows for more freedom of error objects being returned within our API.

LONG LIVE PIPELINES 🚀