### PR TITLE
Username Validation Fix

### DIFF
--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -167,7 +167,7 @@ function Profile() {
             // contains '/'
             setUsernameErrorMessage('Invalid username.')
             return false
-        } else if (!(await isValidUsername(username))) {
+        } else if (await isValidUsername(username)) {
             // invalid regex
             setUsernameErrorMessage('Invalid username.')
             return false


### PR DESCRIPTION
Unfortunately, due to some incorrect logic within the username validation code, all instances of usernames were considered invalid. This PR is a fix for it.

**Validation**
`client/src/pages/Profile.js` - Fixed the logic to accept usernames that follow the regex rules, not the opposite.


LONG LIVE PIPELINES 🚀