### PR TITLE
Admin Token Fix

### DIFF
--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -283,7 +283,7 @@ function Profile() {
 
         try {
             await fetchWithAuth({
-                url: `${HOST}/api/profile/get/${user.profileId}`,
+                url: `${HOST}/api/profile/${user.profileId}`,
                 method: 'PATCH',
                 data: updatedProfile,
             })

--- a/client/src/util/tokenUtils.js
+++ b/client/src/util/tokenUtils.js
@@ -3,12 +3,27 @@ import Cookies from 'js-cookie'
 import { HOST } from './apiRoutes'
 
 export const generateToken = async () => {
-    const linkedinToken = localStorage.getItem('linkedinToken')
-    const adminToken = localStorage.getItem('adminToken')
+    const tokenKeys = ['linkedin', 'admin']
+    const tokenQueries = []
+
+    // loop through tokens needed and fetch them
+    for (const tokenKey of tokenKeys) {
+        const tokenName = `${tokenKey}Token`
+        const token = localStorage.getItem(tokenName)
+
+        // if the token exists, add it to the token pieces
+        if (token) {
+            tokenQueries.push(`${tokenName}=${token}`)
+        }
+    }
+
+    // Construct the URL dynamically based on the tokens array
+    const tokenParams =
+        tokenQueries.length > 0 ? '?' + tokenQueries.join('&') : ''
+    const url = `${HOST}/api/token${tokenParams}`
 
     // Use fetch to get a new session ID if one does not already exist
     try {
-        const url = `${HOST}/api/token${linkedinToken ? `?linkedinToken=${linkedinToken}` : ''}${adminToken ? `&adminToken=${adminToken}` : ''}`
         const response = await fetch(url)
 
         if (!response.ok) {


### PR DESCRIPTION
There was a strange bug where an admin user signed into the admin dashboard before logging into Linkedin and had an invalid token. Fixed this by "arrayizing" the tokens when they are present!

**Bug Fix**
`client/src/util/tokenUtils.js` - Instead of checking for specific tokens, stored the token keys in an array and handled them iteratively.


LONG LIVE PIPELINES! 🚀